### PR TITLE
WIP: Adds static registration of json adapter factories with a single meta factory.

### DIFF
--- a/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiJsonAdapterFactory.java
+++ b/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiJsonAdapterFactory.java
@@ -1,0 +1,34 @@
+package com.ryanharter.auto.value.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Created by rharter on 8/15/15.
+ */
+public class AutoValueMoshiJsonAdapterFactory implements JsonAdapter.Factory {
+
+  public static final Set<JsonAdapter.Factory> FACTORIES = Collections.synchronizedSet(new HashSet<>());
+
+  public static void register(JsonAdapter.Factory factory) {
+    FACTORIES.add(factory);
+  }
+
+  @Override
+  public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {
+    Iterator<JsonAdapter.Factory> it = FACTORIES.iterator();
+    while (it.hasNext()) {
+      JsonAdapter adapter = it.next().create(type, annotations, moshi);
+      if (adapter != null) return adapter;
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
The idea hear is that all of the generated type adapter factories will register themselves with AutoValueMoshiJsonAdapterFactory (that really needs a better name) so that the user only has to register the single meta factory with Moshi.

This is an experiment, I'm not sure that the synchronisity of the adapter set is important since the registration all happens at class load time, but it might need to be synchronized.
