### PR TITLE
Fixes bug in JsonAdapterFactory.create()

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-rootProject.name = 'autogson'
+rootProject.name = 'auto-value-moshi'
 

--- a/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtensionTest.java
+++ b/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtensionTest.java
@@ -2,11 +2,13 @@ package com.ryanharter.auto.value.moshi;
 
 import com.google.auto.value.processor.AutoValueProcessor;
 import com.google.testing.compile.JavaFileObjects;
+
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.tools.JavaFileObject;
 import java.util.Arrays;
+
+import javax.tools.JavaFileObject;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
@@ -76,7 +78,7 @@ public class AutoValueMoshiExtensionTest {
             + "  public static final class AutoValue_TestJsonAdapterFactory implements JsonAdapter.Factory {\n"
             + "    @Override\n"
             + "    public JsonAdapter<Test> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {\n"
-            + "      if (!(type instanceof Test)) return null;\n"
+            + "      if (!type.equals(Test.class)) return null;\n"
             + "      return (JsonAdapter<Test>) new AutoValue_TestJsonAdapter(moshi);\n"
             + "    }\n"
             + "  }\n"


### PR DESCRIPTION
Fixed a bug on `createJsonAdapterFactory` where it was doing `type instanceof TheClass`, where it should be doing `type.equals(TheClass.class)`.

Also cleaned up some stuff and renamed the project, which was `autogson`

Paired with @seana208 on it
