### PR TITLE
Call reader.skipValue() if field not present.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compile 'com.google.auto.value:auto-value:1.2-SNAPSHOT'
     compile 'com.google.auto.service:auto-service:1.0-rc2'
     compile 'com.google.auto:auto-common:1.0-SNAPSHOT'
-    compile 'com.squareup.moshi:moshi:1.0.0-SNAPSHOT'
+    compile 'com.squareup.moshi:moshi:1.0.0'
 
     testCompile 'junit:junit:4.11'
     testCompile 'com.google.truth:truth:0.27'

--- a/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtension.java
+++ b/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtension.java
@@ -289,7 +289,11 @@ public class AutoValueMoshiExtension implements AutoValueExtension {
 
       first = false;
     }
-    readMethod.endControlFlow(); // if/else if
+
+    readMethod.nextControlFlow("else");
+    readMethod.addStatement("$N.skipValue()", reader);
+
+    readMethod.endControlFlow(); // if, else if, else
     readMethod.endControlFlow(); // while
 
     readMethod.addStatement("$N.endObject()", reader);

--- a/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtensionTest.java
+++ b/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtensionTest.java
@@ -139,6 +139,8 @@ public class AutoValueMoshiExtensionTest {
             + "          f = fAdapter.fromJson(reader);\n"
             + "        } else if (\"g\".equals(_name)) {\n"
             + "          g = gAdapter.fromJson(reader);\n"
+            + "        } else {\n"
+            + "          reader.skipValue();\n"
             + "        }\n"
             + "      }\n"
             + "      reader.endObject();\n"


### PR DESCRIPTION
If we have a JSON field that is not present in the Java object, .fromJson() will fail because it didn't consumed the value.

```
                ERROR  E  com.squareup.moshi.JsonDataException: Expected a name but was STRING at path $.results[0].createdAt
```
