### PR TITLE
Add support to any @Nullable annotation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.ryanharter.auto.value
-VERSION_NAME=0.1-SNAPSHOT
+VERSION_NAME=0.2-SNAPSHOT
 
 POM_ARTIFACT_ID=auto-value-moshi
 POM_NAME=AutoValue: Moshi Extension

--- a/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtension.java
+++ b/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtension.java
@@ -48,6 +48,7 @@ public class AutoValueMoshiExtension implements AutoValueExtension {
     String name;
     ExecutableElement element;
     TypeName type;
+    ImmutableSet<String> annotations;
 
     public Property() {}
 
@@ -56,6 +57,7 @@ public class AutoValueMoshiExtension implements AutoValueExtension {
       this.element = element;
 
       type = TypeName.get(element.getReturnType());
+      annotations = buildAnnotations(element);
     }
 
     public String serializedName() {
@@ -68,10 +70,10 @@ public class AutoValueMoshiExtension implements AutoValueExtension {
     }
 
     public Boolean nullable() {
-      return getAnnotations().contains("Nullable");
+      return annotations.contains("Nullable");
     }
 
-    private ImmutableSet<String> getAnnotations() {
+    private ImmutableSet<String> buildAnnotations(ExecutableElement element) {
       ImmutableSet.Builder<String> builder = ImmutableSet.builder();
 
       List<? extends AnnotationMirror> annotations = element.getAnnotationMirrors();

--- a/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtension.java
+++ b/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtension.java
@@ -3,6 +3,7 @@ package com.ryanharter.auto.value.moshi;
 import com.google.auto.service.AutoService;
 import com.google.auto.value.extension.AutoValueExtension;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.CodeBlock;
@@ -31,6 +32,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
 
 import static javax.lang.model.element.Modifier.ABSTRACT;
@@ -63,6 +65,21 @@ public class AutoValueMoshiExtension implements AutoValueExtension {
       } else {
         return name;
       }
+    }
+
+    public Boolean nullable() {
+      return getAnnotations().contains("Nullable");
+    }
+
+    private ImmutableSet<String> getAnnotations() {
+      ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+
+      List<? extends AnnotationMirror> annotations = element.getAnnotationMirrors();
+      for (AnnotationMirror annotation : annotations) {
+        builder.add(annotation.getAnnotationType().asElement().getSimpleName().toString());
+      }
+
+      return builder.build();
     }
   }
 
@@ -243,8 +260,15 @@ public class AutoValueMoshiExtension implements AutoValueExtension {
       Property prop = entry.getKey();
       FieldSpec field = entry.getValue();
 
-      writeMethod.addStatement("$N.name($S)", writer, prop.serializedName());
-      writeMethod.addStatement("$N.toJson($N, $N.$N())", field, writer, value, prop.name);
+      if (prop.nullable()) {
+        writeMethod.beginControlFlow("if ($N.$N() != null)", value, prop.name);
+        writeMethod.addStatement("$N.name($S)", writer, prop.serializedName());
+        writeMethod.addStatement("$N.toJson($N, $N.$N())", field, writer, value, prop.name);
+        writeMethod.endControlFlow();
+      } else {
+        writeMethod.addStatement("$N.name($S)", writer, prop.serializedName());
+        writeMethod.addStatement("$N.toJson($N, $N.$N())", field, writer, value, prop.name);
+      }
     }
     writeMethod.addStatement("$N.endObject()", writer);
 


### PR DESCRIPTION
Support @Nullable fields on `toJson()`

Don't fail on `null` fields annotated with @Nullable.
