### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ An extension for Google's [AutoValue](https://github.com/google/auto) that creat
 
 ## Usage
 
-Simply include auto-value-moshi in your project and add the generated JsonAdapterFactory to your Moshi instance.  You can also annotate your properties using `@SerializedName` to define an alternate name for de/serialization.
+Simply include auto-value-moshi in your project and add the generated JsonAdapterFactory to your Moshi instance.  You can also annotate your properties using `@Json` to define an alternate name for de/serialization.
 
 ```java
 @AutoValue public abstract class Foo {
   abstract String bar();
   @Json(name="Baz") abstract String baz();
 
-  public static TypeAdapterFactory typeAdapterFactory() {
+  public static JsonAdapter.Factory typeAdapterFactory() {
     return AutoValue_Foo.typeAdapterFactory();
   }
 }
@@ -37,7 +37,7 @@ This wouldn't be quite complete without some added features.
 Add a Gradle dependency:
 
 ```groovy
-apt 'com.ryanharter.auto.value:auto-value-moshi:0.1-SNAPSHOT'
+apt 'com.ryanharter.auto.value:auto-value-moshi:0.2-SNAPSHOT'
 ```
 
 (Using the [android-apt](https://bitbucket.org/hvisser/android-apt) plugin)


### PR DESCRIPTION
The current README seems to reference classes which don't exist (`TypeAdapterFactory`) and references the Gson field name annotation instead of the Moshi annotation.
- Use @Json instead of @SerializedName.
- typeAdapterFactory returns a JsonAdapter.Factory instead of a TypeAdapterFactory.
- Update dependency to 0.2-SNAPSHOT.
