### PR TITLE
Add processor options for generated adapter factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,26 @@ final Moshi moshi = new Moshi.Builder()
 
 Now build your project and de/serialize your Foo.
 
-In addition to generating implementations of your `@AutoValue` annotated classes, auto-value-moshi also generates an `AutoValueMoshiAdapterFactory` class which you can register with Moshi to automatically add all of your generated JsonAdapters.
+In addition to generating implementations of your `@AutoValue` annotated classes, auto-value-moshi 
+also generates an `AutoValueMoshiAdapterFactory` class which you can register with Moshi to 
+automatically add all of your generated JsonAdapters. If you want to customize the generated class, 
+you can specify the corresponding `moshiAdapterPackage` and `moshiAdapterName` processing args like
+so:
+
+```gradle
+apt {
+ arguments {
+   moshiAdapterPackage 'com.example'
+   moshiAdapterName 'AdapterFactory'
+ }
+}
+```
 
 ## Download
 
 Add a Gradle dependency:
 
-```groovy
+```gradle
 apt 'com.ryanharter.auto.value:auto-value-moshi:0.3.3-rc1'
 ```
 

--- a/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessor.java
+++ b/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessor.java
@@ -43,6 +43,8 @@ import static javax.lang.model.element.Modifier.PUBLIC;
 @AutoService(Processor.class)
 public class AutoValueMoshiAdapterFactoryProcessor extends AbstractProcessor {
 
+  static final String ADAPTER_NAME = "moshiAdapterName";
+  static final String ADAPTER_PACKAGE = "moshiAdapterPackage";
   private final AutoValueMoshiExtension extension = new AutoValueMoshiExtension();
 
   @Override
@@ -66,8 +68,16 @@ public class AutoValueMoshiAdapterFactoryProcessor extends AbstractProcessor {
     }
 
     if (!elements.isEmpty()) {
-      TypeSpec jsonAdapterFactory = createJsonAdapterFactory(elements);
-      JavaFile file = JavaFile.builder("com.ryanharter.auto.value.moshi", jsonAdapterFactory).build();
+      String packageName = "com.ryanharter.auto.value.moshi";
+      String adapterName = "AutoValueMoshiAdapterFactory";
+      if (processingEnv.getOptions().containsKey(ADAPTER_PACKAGE)) {
+        packageName = processingEnv.getOptions().get(ADAPTER_PACKAGE);
+      }
+      if (processingEnv.getOptions().containsKey(ADAPTER_NAME)) {
+        adapterName = processingEnv.getOptions().get(ADAPTER_NAME);
+      }
+      TypeSpec jsonAdapterFactory = createJsonAdapterFactory(elements, packageName, adapterName);
+      JavaFile file = JavaFile.builder(packageName, jsonAdapterFactory).build();
       try {
         file.writeTo(processingEnv.getFiler());
       } catch (IOException e) {
@@ -78,8 +88,11 @@ public class AutoValueMoshiAdapterFactoryProcessor extends AbstractProcessor {
     return false;
   }
 
-  private TypeSpec createJsonAdapterFactory(List<Element> elements) {
-    TypeSpec.Builder factory = TypeSpec.classBuilder(ClassName.get("com.ryanharter.auto.value.moshi", "AutoValueMoshiAdapterFactory"));
+  private TypeSpec createJsonAdapterFactory(
+      List<Element> elements,
+      String packageName,
+      String adapterName) {
+    TypeSpec.Builder factory = TypeSpec.classBuilder(ClassName.get(packageName, adapterName));
     factory.addModifiers(PUBLIC, FINAL);
     factory.addSuperinterface(TypeName.get(JsonAdapter.Factory.class));
 

--- a/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessorTest.java
+++ b/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessorTest.java
@@ -1,16 +1,15 @@
 package com.ryanharter.auto.value.moshi;
 
-import com.google.auto.value.processor.AutoValueProcessor;
 import com.google.common.collect.ImmutableSet;
 import com.google.testing.compile.JavaFileObjects;
-import java.util.Arrays;
-import javax.tools.JavaFileObject;
 import org.junit.Test;
 
+import javax.tools.JavaFileObject;
+
 import static com.google.common.truth.Truth.assertAbout;
-import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
-import static org.junit.Assert.*;
+import static com.ryanharter.auto.value.moshi.AutoValueMoshiAdapterFactoryProcessor.ADAPTER_NAME;
+import static com.ryanharter.auto.value.moshi.AutoValueMoshiAdapterFactoryProcessor.ADAPTER_PACKAGE;
 
 /**
  * Created by rharter on 4/27/16.
@@ -66,6 +65,63 @@ public class AutoValueMoshiAdapterFactoryProcessorTest {
         + "}");
     assertAbout(javaSources())
         .that(ImmutableSet.of(source1, source2))
+        .processedWith(new AutoValueMoshiAdapterFactoryProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expected);
+  }
+
+  @Test public void args_generateJsonAdapterFactory_withCustomPackageAndName() {
+    JavaFileObject source1 = JavaFileObjects.forSourceString("test.Foo", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "@AutoValue public abstract class Foo {\n"
+        + "  public static JsonAdapter<Foo> jsonAdapter(Moshi moshi) {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "  public abstract String getName();\n"
+        + "  public abstract boolean isAwesome();\n"
+        + "}");
+    JavaFileObject source2 = JavaFileObjects.forSourceString("test.Bar", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "@AutoValue public abstract class Bar {\n"
+        + "  public static JsonAdapter<Bar> jsonAdapter(Moshi moshi) {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "  public abstract String getName();\n"
+        + "}");
+    JavaFileObject expected = JavaFileObjects.forSourceString("testpackage.SomeAdapterFactory", ""
+        + "package testpackage;\n"
+        + "\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.annotation.Annotation;\n"
+        + "import java.lang.reflect.Type;\n"
+        + "import java.util.Set;\n"
+        + "import test.Bar;\n"
+        + "import test.Foo;\n"
+        + "\n"
+        + "public final class SomeAdapterFactory implements JsonAdapter.Factory {\n"
+        + "  @Override public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {\n"
+        + "    if (type.equals(Foo.class)) {\n"
+        + "      return Foo.jsonAdapter(moshi);\n"
+        + "    } else if (type.equals(Bar.class)) {\n"
+        + "      return Bar.jsonAdapter(moshi);\n"
+        + "    } else {\n"
+        + "      return null;\n"
+        + "    }\n"
+        + "  }\n"
+        + "}");
+    assertAbout(javaSources())
+        .that(ImmutableSet.of(source1, source2))
+        .withCompilerOptions("-A" + ADAPTER_PACKAGE + "=testpackage")
+        .withCompilerOptions("-A" + ADAPTER_NAME + "=SomeAdapterFactory")
         .processedWith(new AutoValueMoshiAdapterFactoryProcessor())
         .compilesWithoutError()
         .and()


### PR DESCRIPTION
Partially resolves #40

I like the `@MoshiAdapterFactory` approach as well, and can follow this up with another PR that adds support for that for flexibility (especially since JACK's processing doesn't support args).

Assuming this gets merged, I'll open a corresponding PR for auto-value-gson
