### PR TITLE
Switch to autovalue-esque style of generating Factories

### DIFF
--- a/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessor.java
+++ b/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessor.java
@@ -79,27 +79,23 @@ public class AutoValueMoshiAdapterFactoryProcessor extends AbstractProcessor {
 
     if (!elements.isEmpty()) {
       Set<? extends Element> adaptorFactories = roundEnv.getElementsAnnotatedWith(MoshiAdapterFactory.class);
-      if (adaptorFactories.isEmpty()) {
-        error(elements.get(0), "Missing MoshiAdapterFactory class. In order to generate the class, you need to create an abstract class with the @MoshiAdapterFactory annotation that implements JsonAdapter.Factory.");
-      } else {
-        for (Element element : adaptorFactories) {
-          if (!element.getModifiers().contains(ABSTRACT)) {
-            error(element, "Must be abstract!");
-          }
-          TypeElement type = (TypeElement) element; // Safe to case because this is only applicable on types anyway
-          List<? extends TypeMirror> interfaces = type.getInterfaces();
-          if (interfaces.isEmpty() || !containsJsonAdapterFactoryMirror(interfaces)) {
-            error(element, "Must implement JsonAdapter.Factory!");
-          }
-          String adapterName = classNameOf(type);
-          String packageName = packageNameOf(type);
-          TypeSpec jsonAdapterFactory = createJsonAdapterFactory(elements, packageName, adapterName);
-          JavaFile file = JavaFile.builder(packageName, jsonAdapterFactory).build();
-          try {
-            file.writeTo(processingEnv.getFiler());
-          } catch (IOException e) {
-            processingEnv.getMessager().printMessage(ERROR, "Failed to write TypeAdapterFactory: " + e.getLocalizedMessage());
-          }
+      for (Element element : adaptorFactories) {
+        if (!element.getModifiers().contains(ABSTRACT)) {
+          error(element, "Must be abstract!");
+        }
+        TypeElement type = (TypeElement) element; // Safe to case because this is only applicable on types anyway
+        List<? extends TypeMirror> interfaces = type.getInterfaces();
+        if (interfaces.isEmpty() || !containsJsonAdapterFactoryMirror(interfaces)) {
+          error(element, "Must implement JsonAdapter.Factory!");
+        }
+        String adapterName = classNameOf(type);
+        String packageName = packageNameOf(type);
+        TypeSpec jsonAdapterFactory = createJsonAdapterFactory(elements, packageName, adapterName);
+        JavaFile file = JavaFile.builder(packageName, jsonAdapterFactory).build();
+        try {
+          file.writeTo(processingEnv.getFiler());
+        } catch (IOException e) {
+          processingEnv.getMessager().printMessage(ERROR, "Failed to write TypeAdapterFactory: " + e.getLocalizedMessage());
         }
       }
     }

--- a/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessor.java
+++ b/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessor.java
@@ -171,9 +171,10 @@ public class AutoValueMoshiAdapterFactoryProcessor extends AbstractProcessor {
   }
 
   private boolean containsJsonAdapterFactoryMirror(List<? extends TypeMirror> interfaces) {
+    TypeMirror jsonAdapterType
+        = elementUtils.getTypeElement(JsonAdapter.Factory.class.getCanonicalName()).asType();
     for (TypeMirror type : interfaces) {
-      if (typeUtils.isSameType(type,
-          elementUtils.getTypeElement(JsonAdapter.Factory.class.getCanonicalName()).asType())) {
+      if (typeUtils.isSameType(type, jsonAdapterType)) {
         return true;
       }
     }

--- a/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessor.java
+++ b/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessor.java
@@ -83,7 +83,7 @@ public class AutoValueMoshiAdapterFactoryProcessor extends AbstractProcessor {
         if (!element.getModifiers().contains(ABSTRACT)) {
           error(element, "Must be abstract!");
         }
-        TypeElement type = (TypeElement) element; // Safe to case because this is only applicable on types anyway
+        TypeElement type = (TypeElement) element; // Safe to cast because this is only applicable on types anyway
         List<? extends TypeMirror> interfaces = type.getInterfaces();
         if (interfaces.isEmpty() || !containsJsonAdapterFactoryMirror(interfaces)) {
           error(element, "Must implement JsonAdapter.Factory!");

--- a/src/main/java/com/ryanharter/auto/value/moshi/MoshiAdapterFactory.java
+++ b/src/main/java/com/ryanharter/auto/value/moshi/MoshiAdapterFactory.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 /**
  * Annotation to indicate that a given class should generate a concrete implementation of a
@@ -21,7 +21,7 @@ import static java.lang.annotation.RetentionPolicy.CLASS;
  *   }
  * </pre></code>
  */
-@Retention(CLASS)
+@Retention(SOURCE)
 @Target(TYPE)
 public @interface MoshiAdapterFactory {
 }

--- a/src/main/java/com/ryanharter/auto/value/moshi/MoshiAdapterFactory.java
+++ b/src/main/java/com/ryanharter/auto/value/moshi/MoshiAdapterFactory.java
@@ -1,0 +1,27 @@
+package com.ryanharter.auto.value.moshi;
+
+import com.squareup.moshi.JsonAdapter;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/**
+ * Annotation to indicate that a given class should generate a concrete implementation of a
+ * {@link JsonAdapter.Factory} that handles all the publicly denoted adapter implementations of this
+ * project.
+ * <p>
+ * <code><pre>
+ *   &#64;MoshiAdapterFactory
+ *   public abstract class Factory implements JsonAdapter.Factory {
+ *     public static Factory create() {
+ *       return new AutoValueMoshi_Factory();
+ *     }
+ *   }
+ * </pre></code>
+ */
+@Retention(CLASS)
+@Target(TYPE)
+public @interface MoshiAdapterFactory {
+}

--- a/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessorTest.java
+++ b/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessorTest.java
@@ -1,16 +1,12 @@
 package com.ryanharter.auto.value.moshi;
 
-import com.google.auto.value.processor.AutoValueProcessor;
 import com.google.common.collect.ImmutableSet;
 import com.google.testing.compile.JavaFileObjects;
-import java.util.Arrays;
 import javax.tools.JavaFileObject;
 import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
-import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
-import static org.junit.Assert.*;
 
 /**
  * Created by rharter on 4/27/16.
@@ -41,8 +37,19 @@ public class AutoValueMoshiAdapterFactoryProcessorTest {
         + "  }\n"
         + "  public abstract String getName();\n"
         + "}");
-    JavaFileObject expected = JavaFileObjects.forSourceString("com.ryanharter.auto.value.moshi.AutoValueMoshiJsonAdapterFactory", ""
-        + "package com.ryanharter.auto.value.moshi;\n"
+    JavaFileObject source3 = JavaFileObjects.forSourceString("test.MyAdapterFactory", ""
+        + "package test;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "import com.ryanharter.auto.value.moshi.MoshiAdapterFactory;\n"
+        + "@MoshiAdapterFactory\n"
+        + "public abstract class MyAdapterFactory implements JsonAdapter.Factory {\n"
+        + "  public static JsonAdapter.Factory create() {\n"
+        + "    return new AutoValueMoshi_MyAdapterFactory();\n"
+        + "  }\n"
+        + "}");
+    JavaFileObject expected = JavaFileObjects.forSourceString("test.AutoValueMoshi_MyAdapterFactory", ""
+        + "package test;\n"
         + "\n"
         + "import com.squareup.moshi.JsonAdapter;\n"
         + "import com.squareup.moshi.Moshi;\n"
@@ -50,10 +57,8 @@ public class AutoValueMoshiAdapterFactoryProcessorTest {
         + "import java.lang.annotation.Annotation;\n"
         + "import java.lang.reflect.Type;\n"
         + "import java.util.Set;\n"
-        + "import test.Bar;\n"
-        + "import test.Foo;\n"
         + "\n"
-        + "public final class AutoValueMoshiAdapterFactory implements JsonAdapter.Factory {\n"
+        + "public final class AutoValueMoshi_MyAdapterFactory extends MyAdapterFactory {\n"
         + "  @Override public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {\n"
         + "    if (type.equals(Foo.class)) {\n"
         + "      return Foo.jsonAdapter(moshi);\n"
@@ -65,10 +70,92 @@ public class AutoValueMoshiAdapterFactoryProcessorTest {
         + "  }\n"
         + "}");
     assertAbout(javaSources())
-        .that(ImmutableSet.of(source1, source2))
+        .that(ImmutableSet.of(source1, source2, source3))
         .processedWith(new AutoValueMoshiAdapterFactoryProcessor())
         .compilesWithoutError()
         .and()
         .generatesSources(expected);
+  }
+
+  @Test public void generatesJsonAdapterFactory_notAbstract_shouldFail() {
+    JavaFileObject source1 = JavaFileObjects.forSourceString("test.Foo", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "@AutoValue public abstract class Foo {\n"
+        + "  public static JsonAdapter<Foo> jsonAdapter(Moshi moshi) {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "  public abstract String getName();\n"
+        + "  public abstract boolean isAwesome();\n"
+        + "}");
+    JavaFileObject source2 = JavaFileObjects.forSourceString("test.MyAdapterFactory", ""
+        + "package test;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "import com.ryanharter.auto.value.moshi.MoshiAdapterFactory;\n"
+        + "@MoshiAdapterFactory\n"
+        + "public class MyAdapterFactory implements JsonAdapter.Factory {\n"
+        + "  public static JsonAdapter.Factory create() {\n"
+        + "    return new AutoValueMoshi_MyAdapterFactory();\n"
+        + "  }\n"
+        + "}");
+    assertAbout(javaSources())
+        .that(ImmutableSet.of(source1, source2))
+        .processedWith(new AutoValueMoshiAdapterFactoryProcessor())
+        .failsToCompile()
+        .withErrorContaining("Must be abstract!");
+  }
+
+  @Test public void generatesJsonAdapterFactory_doesNotImplementFactory_shouldFail() {
+    JavaFileObject source1 = JavaFileObjects.forSourceString("test.Foo", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "@AutoValue public abstract class Foo {\n"
+        + "  public static JsonAdapter<Foo> jsonAdapter(Moshi moshi) {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "  public abstract String getName();\n"
+        + "  public abstract boolean isAwesome();\n"
+        + "}");
+    JavaFileObject source2 = JavaFileObjects.forSourceString("test.MyAdapterFactory", ""
+        + "package test;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "import com.ryanharter.auto.value.moshi.MoshiAdapterFactory;\n"
+        + "@MoshiAdapterFactory\n"
+        + "public abstract class MyAdapterFactory {\n"
+        + "  public static JsonAdapter.Factory create() {\n"
+        + "    return new AutoValueMoshi_MyAdapterFactory();\n"
+        + "  }\n"
+        + "}");
+    assertAbout(javaSources())
+        .that(ImmutableSet.of(source1, source2))
+        .processedWith(new AutoValueMoshiAdapterFactoryProcessor())
+        .failsToCompile()
+        .withErrorContaining("Must implement JsonAdapter.Factory!");
+  }
+
+  @Test public void generatesJsonAdapterFactory_missingFactory_shouldFail() {
+    JavaFileObject source1 = JavaFileObjects.forSourceString("test.Foo", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "@AutoValue public abstract class Foo {\n"
+        + "  public static JsonAdapter<Foo> jsonAdapter(Moshi moshi) {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "  public abstract String getName();\n"
+        + "  public abstract boolean isAwesome();\n"
+        + "}");
+    assertAbout(javaSources())
+        .that(ImmutableSet.of(source1))
+        .processedWith(new AutoValueMoshiAdapterFactoryProcessor())
+        .failsToCompile()
+        .withErrorContaining("Missing MoshiAdapterFactory class");
   }
 }

--- a/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessorTest.java
+++ b/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessorTest.java
@@ -174,7 +174,7 @@ public class AutoValueMoshiAdapterFactoryProcessorTest {
         + "import com.squareup.moshi.Moshi;\n"
         + "import com.ryanharter.auto.value.moshi.MoshiAdapterFactory;\n"
         + "@MoshiAdapterFactory\n"
-        + "public abstract class MyAdapterFactory implements JsonAdapter.Factory {\n"
+        + "public abstract class MyAdapterFactory extends MyAdapterFactoryBase {\n"
         + "  public static JsonAdapter.Factory create() {\n"
         + "    return new AutoValueMoshi_MyAdapterFactory();\n"
         + "  }\n"
@@ -202,6 +202,80 @@ public class AutoValueMoshiAdapterFactoryProcessorTest {
             + "  }\n"
             + "}");
     assertAbout(javaSources()).that(ImmutableSet.of(source1, source2, source3, source4))
+        .processedWith(new AutoValueMoshiAdapterFactoryProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expected);
+  }
+
+  @Test public void generatesJsonAdapterFactory_shouldSearchUpComplexAncestry() {
+    JavaFileObject source1 = JavaFileObjects.forSourceString("test.Foo", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "@AutoValue public abstract class Foo {\n"
+        + "  public static JsonAdapter<Foo> jsonAdapter(Moshi moshi) {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "  public abstract String getName();\n"
+        + "  public abstract boolean isAwesome();\n"
+        + "}");
+    JavaFileObject source2 = JavaFileObjects.forSourceString("test.Bar", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "@AutoValue public abstract class Bar {\n"
+        + "  public static JsonAdapter<Bar> jsonAdapter(Moshi moshi) {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "  public abstract String getName();\n"
+        + "}");
+    JavaFileObject source3 = JavaFileObjects.forSourceString("test.IMyAdapterFactoryBase", ""
+        + "package test;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "public interface IMyAdapterFactoryBase extends JsonAdapter.Factory {\n"
+        + "}");
+    JavaFileObject source4 = JavaFileObjects.forSourceString("test.MyAdapterFactoryBase", ""
+        + "package test;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "public abstract class MyAdapterFactoryBase implements IMyAdapterFactoryBase {\n"
+        + "}");
+    JavaFileObject source5 = JavaFileObjects.forSourceString("test.MyAdapterFactory", ""
+        + "package test;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "import com.ryanharter.auto.value.moshi.MoshiAdapterFactory;\n"
+        + "@MoshiAdapterFactory\n"
+        + "public abstract class MyAdapterFactory extends MyAdapterFactoryBase {\n"
+        + "  public static JsonAdapter.Factory create() {\n"
+        + "    return new AutoValueMoshi_MyAdapterFactory();\n"
+        + "  }\n"
+        + "}");
+    JavaFileObject expected =
+        JavaFileObjects.forSourceString("test.AutoValueMoshi_MyAdapterFactory", ""
+            + "package test;\n"
+            + "\n"
+            + "import com.squareup.moshi.JsonAdapter;\n"
+            + "import com.squareup.moshi.Moshi;\n"
+            + "import java.lang.Override;\n"
+            + "import java.lang.annotation.Annotation;\n"
+            + "import java.lang.reflect.Type;\n"
+            + "import java.util.Set;\n"
+            + "\n"
+            + "public final class AutoValueMoshi_MyAdapterFactory extends MyAdapterFactory {\n"
+            + "  @Override public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {\n"
+            + "    if (type.equals(Foo.class)) {\n"
+            + "      return Foo.jsonAdapter(moshi);\n"
+            + "    } else if (type.equals(Bar.class)) {\n"
+            + "      return Bar.jsonAdapter(moshi);\n"
+            + "    } else {\n"
+            + "      return null;\n"
+            + "    }\n"
+            + "  }\n"
+            + "}");
+    assertAbout(javaSources()).that(ImmutableSet.of(source1, source2, source3, source4, source5))
         .processedWith(new AutoValueMoshiAdapterFactoryProcessor())
         .compilesWithoutError()
         .and()

--- a/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessorTest.java
+++ b/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessorTest.java
@@ -138,24 +138,4 @@ public class AutoValueMoshiAdapterFactoryProcessorTest {
         .failsToCompile()
         .withErrorContaining("Must implement JsonAdapter.Factory!");
   }
-
-  @Test public void generatesJsonAdapterFactory_missingFactory_shouldFail() {
-    JavaFileObject source1 = JavaFileObjects.forSourceString("test.Foo", ""
-        + "package test;\n"
-        + "import com.google.auto.value.AutoValue;\n"
-        + "import com.squareup.moshi.JsonAdapter;\n"
-        + "import com.squareup.moshi.Moshi;\n"
-        + "@AutoValue public abstract class Foo {\n"
-        + "  public static JsonAdapter<Foo> jsonAdapter(Moshi moshi) {\n"
-        + "    return null;\n"
-        + "  }\n"
-        + "  public abstract String getName();\n"
-        + "  public abstract boolean isAwesome();\n"
-        + "}");
-    assertAbout(javaSources())
-        .that(ImmutableSet.of(source1))
-        .processedWith(new AutoValueMoshiAdapterFactoryProcessor())
-        .failsToCompile()
-        .withErrorContaining("Missing MoshiAdapterFactory class");
-  }
 }

--- a/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessorTest.java
+++ b/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessorTest.java
@@ -138,4 +138,40 @@ public class AutoValueMoshiAdapterFactoryProcessorTest {
         .failsToCompile()
         .withErrorContaining("Must implement JsonAdapter.Factory!");
   }
+
+  @Test public void generatesJsonAdapterFactory_shouldSearchUpAncestry() {
+    JavaFileObject source1 = JavaFileObjects.forSourceString("test.Foo", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "@AutoValue public abstract class Foo {\n"
+        + "  public static JsonAdapter<Foo> jsonAdapter(Moshi moshi) {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "  public abstract String getName();\n"
+        + "  public abstract boolean isAwesome();\n"
+        + "}");
+    JavaFileObject source2 = JavaFileObjects.forSourceString("test.MyAdapterFactoryBase", ""
+        + "package test;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "public abstract class MyAdapterFactoryBase implements JsonAdapter.Factory {\n"
+        + "}");
+    JavaFileObject source3 = JavaFileObjects.forSourceString("test.MyAdapterFactory", ""
+        + "package test;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "import com.ryanharter.auto.value.moshi.MoshiAdapterFactory;\n"
+        + "@MoshiAdapterFactory\n"
+        + "public abstract class MyAdapterFactory extends MyAdapterFactoryBase {\n"
+        + "  public static JsonAdapter.Factory create() {\n"
+        + "    return new AutoValueMoshi_MyAdapterFactory();\n"
+        + "  }\n"
+        + "}");
+    assertAbout(javaSources())
+        .that(ImmutableSet.of(source1, source2, source3))
+        .processedWith(new AutoValueMoshiAdapterFactoryProcessor())
+        .failsToCompile()
+        .withErrorContaining("Must implement JsonAdapter.Factory!");
+  }
 }

--- a/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessorTest.java
+++ b/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessorTest.java
@@ -152,26 +152,59 @@ public class AutoValueMoshiAdapterFactoryProcessorTest {
         + "  public abstract String getName();\n"
         + "  public abstract boolean isAwesome();\n"
         + "}");
-    JavaFileObject source2 = JavaFileObjects.forSourceString("test.MyAdapterFactoryBase", ""
+    JavaFileObject source2 = JavaFileObjects.forSourceString("test.Bar", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "@AutoValue public abstract class Bar {\n"
+        + "  public static JsonAdapter<Bar> jsonAdapter(Moshi moshi) {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "  public abstract String getName();\n"
+        + "}");
+    JavaFileObject source3 = JavaFileObjects.forSourceString("test.MyAdapterFactoryBase", ""
         + "package test;\n"
         + "import com.squareup.moshi.JsonAdapter;\n"
         + "public abstract class MyAdapterFactoryBase implements JsonAdapter.Factory {\n"
         + "}");
-    JavaFileObject source3 = JavaFileObjects.forSourceString("test.MyAdapterFactory", ""
+    JavaFileObject source4 = JavaFileObjects.forSourceString("test.MyAdapterFactory", ""
         + "package test;\n"
         + "import com.squareup.moshi.JsonAdapter;\n"
         + "import com.squareup.moshi.Moshi;\n"
         + "import com.ryanharter.auto.value.moshi.MoshiAdapterFactory;\n"
         + "@MoshiAdapterFactory\n"
-        + "public abstract class MyAdapterFactory extends MyAdapterFactoryBase {\n"
+        + "public abstract class MyAdapterFactory implements JsonAdapter.Factory {\n"
         + "  public static JsonAdapter.Factory create() {\n"
         + "    return new AutoValueMoshi_MyAdapterFactory();\n"
         + "  }\n"
         + "}");
-    assertAbout(javaSources())
-        .that(ImmutableSet.of(source1, source2, source3))
+    JavaFileObject expected =
+        JavaFileObjects.forSourceString("test.AutoValueMoshi_MyAdapterFactory", ""
+            + "package test;\n"
+            + "\n"
+            + "import com.squareup.moshi.JsonAdapter;\n"
+            + "import com.squareup.moshi.Moshi;\n"
+            + "import java.lang.Override;\n"
+            + "import java.lang.annotation.Annotation;\n"
+            + "import java.lang.reflect.Type;\n"
+            + "import java.util.Set;\n"
+            + "\n"
+            + "public final class AutoValueMoshi_MyAdapterFactory extends MyAdapterFactory {\n"
+            + "  @Override public JsonAdapter<?> create(Type type, Set<? extends Annotation> annotations, Moshi moshi) {\n"
+            + "    if (type.equals(Foo.class)) {\n"
+            + "      return Foo.jsonAdapter(moshi);\n"
+            + "    } else if (type.equals(Bar.class)) {\n"
+            + "      return Bar.jsonAdapter(moshi);\n"
+            + "    } else {\n"
+            + "      return null;\n"
+            + "    }\n"
+            + "  }\n"
+            + "}");
+    assertAbout(javaSources()).that(ImmutableSet.of(source1, source2, source3, source4))
         .processedWith(new AutoValueMoshiAdapterFactoryProcessor())
-        .failsToCompile()
-        .withErrorContaining("Must implement JsonAdapter.Factory!");
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expected);
   }
 }


### PR DESCRIPTION
Followup from #46 and resolves #40. This would be a breaking change, but for the better I think as it'd be a bit muddled to try to maintain the old behavior and this one's as well.

Now, people would have to declare their own `@MoshiAdapterFactory` class(es) to specify where they want it generated.

Works like @JakeWharton's example in #40: 

``` java
@MoshiAdapterFactory
public abstract class Factory implements JsonAdapter.Factory {
 public static Factory create() {
   return new AutoValueMoshi_Factory();
 }
}
```

Open question - force single usage or allow them to specify as many as they want? Currently the latter, maybe easier to maintain.

Also, I don't _think_ the annotation needs to be in a separate artifact since it's only needed at compile-time, but let me know if I'm wrong.

If this goes well, I'll open a corresponding PR in auto-value-gson.
