### PR TITLE
Make generated factory request null safe adapters.

### DIFF
--- a/auto-value-moshi-annotations/src/main/java/com/ryanharter/auto/value/moshi/MoshiAdapterFactory.java
+++ b/auto-value-moshi-annotations/src/main/java/com/ryanharter/auto/value/moshi/MoshiAdapterFactory.java
@@ -24,4 +24,9 @@ import static java.lang.annotation.RetentionPolicy.SOURCE;
 @Retention(SOURCE)
 @Target(TYPE)
 public @interface MoshiAdapterFactory {
+  /**
+   * Indicates if the generated factory should request {@code null} safe adapters
+   * (default {@code false}).
+   */
+  boolean nullSafe() default false;
 }

--- a/auto-value-moshi/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtension.java
+++ b/auto-value-moshi/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtension.java
@@ -57,7 +57,7 @@ import static javax.lang.model.element.Modifier.STATIC;
 
 @AutoService(AutoValueExtension.class)
 public class AutoValueMoshiExtension extends AutoValueExtension {
-  private static final ClassName ADAPTER_CLASS_NAME = ClassName.get(JsonAdapter.class);
+  static final ClassName ADAPTER_CLASS_NAME = ClassName.get(JsonAdapter.class);
 
   public static class Property {
     final String methodName;

--- a/auto-value-moshi/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessorTest.java
+++ b/auto-value-moshi/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessorTest.java
@@ -8,11 +8,7 @@ import org.junit.Test;
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 
-/**
- * Created by rharter on 4/27/16.
- */
-public class AutoValueMoshiAdapterFactoryProcessorTest {
-
+public final class AutoValueMoshiAdapterFactoryProcessorTest {
   @Test public void generatesJsonAdapterFactory() {
     JavaFileObject source1 = JavaFileObjects.forSourceString("test.Foo", ""
         + "package test;\n"
@@ -391,6 +387,84 @@ public class AutoValueMoshiAdapterFactoryProcessorTest {
             + "  }\n"
             + "}");
     assertAbout(javaSources()).that(ImmutableSet.of(source1, source3))
+        .processedWith(new AutoValueMoshiAdapterFactoryProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expected);
+  }
+
+  @Test public void generatesJsonAdapterFactoryThatReturnsNullSafeAdapters() throws Exception {
+    JavaFileObject source1 = JavaFileObjects.forSourceString("test.Foo", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "import java.lang.reflect.Type;\n"
+        + "import java.util.List;\n"
+        + "@AutoValue public abstract class Foo<V, T> {\n"
+        + "  public static <V, T> JsonAdapter<Foo<V, T>> jsonAdapter(Moshi moshi, "
+        + "      Type[] types) {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "  public abstract List<V> getItems();\n"
+        + "  public abstract List<T> getHeaders();\n"
+        + "}");
+    JavaFileObject source2 = JavaFileObjects.forSourceString("test.Bar", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "import java.lang.reflect.Type;\n"
+        + "import java.util.List;\n"
+        + "@AutoValue public abstract class Bar {\n"
+        + "  public static JsonAdapter<Bar> jsonAdapter(Moshi moshi) {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "  public abstract String value();\n"
+        + "}");
+    JavaFileObject source3 = JavaFileObjects.forSourceString("test.MyAdapterFactory", ""
+        + "package test.factory;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "import com.ryanharter.auto.value.moshi.MoshiAdapterFactory;\n"
+        + "@MoshiAdapterFactory(nullSafe = true)\n"
+        + "public abstract class MyAdapterFactory implements JsonAdapter.Factory {\n"
+        + "  public static JsonAdapter.Factory create() {\n"
+        + "    return new AutoValueMoshi_MyAdapterFactory();\n"
+        + "  }\n"
+        + "}");
+    JavaFileObject expected =
+        JavaFileObjects.forSourceString("test.AutoValueMoshi_MyAdapterFactory", ""
+            + "package test.factory;\n"
+            + "import com.squareup.moshi.JsonAdapter;\n"
+            + "import com.squareup.moshi.Moshi;\n"
+            + "import java.lang.Override;\n"
+            + "import java.lang.annotation.Annotation;\n"
+            + "import java.lang.reflect.ParameterizedType;\n"
+            + "import java.lang.reflect.Type;\n"
+            + "import java.util.Set;\n"
+            + "import test.Bar;\n"
+            + "import test.Foo;\n"
+            + "\n"
+            + "public final class AutoValueMoshi_MyAdapterFactory extends MyAdapterFactory {\n"
+            + "  @Override public JsonAdapter<?> create(Type type,"
+            + "      Set<? extends Annotation> annotations, Moshi moshi) {\n"
+            + "    if (!annotations.isEmpty()) return null;\n"
+            + "    if (type instanceof ParameterizedType) {\n"
+            + "      Type rawType = ((ParameterizedType) type).getRawType();\n"
+            + "      if (rawType.equals(Foo.class)) {\n"
+            + "        return Foo.jsonAdapter(moshi, "
+            + "          ((ParameterizedType) type).getActualTypeArguments()).nullSafe();\n"
+            + "      }\n"
+            + "      return null;\n"
+            + "    }\n"
+            + "    if (type.equals(Bar.class)) {\n"
+            + "      return Bar.jsonAdapter(moshi).nullSafe();\n"
+            + "    }\n"
+            + "    return null;\n"
+            + "  }\n"
+            + "}");
+    assertAbout(javaSources()).that(ImmutableSet.of(source1, source2, source3))
         .processedWith(new AutoValueMoshiAdapterFactoryProcessor())
         .compilesWithoutError()
         .and()

--- a/auto-value-moshi/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtensionTest.java
+++ b/auto-value-moshi/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtensionTest.java
@@ -12,8 +12,7 @@ import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourceSubjectFactory.javaSource;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
 
-public class AutoValueMoshiExtensionTest {
-
+public final class AutoValueMoshiExtensionTest {
   private JavaFileObject serializedName;
   private JavaFileObject nullable;
 


### PR DESCRIPTION
- Introduces nullSafe() element to MoshiAdapterFactory annotation with a
  default value as false (to respect current usages of the library).
- Generated MoshiAdapterFactory will request null safe adapters if
  requested by the user.
- Some minor cleanups (reduced amount of spec and type lookups)

Closes #25 

**Reasoning for extra meta data in the annotation: ** AutoValue by default enforces null safety and users have to explicitly specify that a value is allowed to be null. I reasoned that current users of the library may not expect nulls in their value classes thus such a change could break expected behaviour. This will force users to make a conscious decision wether or not they need their adapters to return null.