### PR TITLE
set auto-service to compileOnly

### DIFF
--- a/auto-value-moshi/build.gradle
+++ b/auto-value-moshi/build.gradle
@@ -8,7 +8,7 @@ dependencies {
   compile project(':auto-value-moshi-annotations')
   compile libraries.javaPoet
   compile libraries.autoValue
-  compile libraries.autoService
+  compileOnly libraries.autoService
   compile libraries.autoCommon
   compile libraries.moshi
 


### PR DESCRIPTION
It's only needed at compile time to generate the service file.