### PR TITLE
Bump dependencies and include `idea` plugin

### DIFF
--- a/auto-value-moshi-tests/build.gradle
+++ b/auto-value-moshi-tests/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'net.ltgt.apt'
 apply plugin: 'java'
+apply plugin: 'idea'
 
 sourceCompatibility = versions.java
 targetCompatibility = versions.java

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -10,8 +10,8 @@ ext {
         autoCommon    : '0.6',
         moshi         : '1.4.0',
         // For testing
-        junit         : '4.11',
-        truth         : '0.27',
+        junit         : '4.12',
+        truth         : '0.32',
         compileTesting: '0.9',
         assertJ       : '2.5.0',
     ]


### PR DESCRIPTION
The idea plugin allows the apt plugin to put generated code on the active source modules list, which means you can actually edit/play with them and use them in the debugger.