### PR TITLE
Only match on actual return type, not any parameterized type

### DIFF
--- a/auto-value-moshi/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessor.java
+++ b/auto-value-moshi/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiAdapterFactoryProcessor.java
@@ -237,7 +237,7 @@ public class AutoValueMoshiAdapterFactoryProcessor extends AbstractProcessor {
           && method.getModifiers().contains(Modifier.PUBLIC)) {
         TypeMirror rType = method.getReturnType();
         TypeName returnType = TypeName.get(rType);
-        if (returnType.equals(jsonAdapterType) || returnType instanceof ParameterizedTypeName) {
+        if (returnType.equals(jsonAdapterType)) {
           return method;
         }
       }


### PR DESCRIPTION
Fixes #82