### PR TITLE
use annotationProcessor instead of apt for gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,12 @@ Moshi moshi = new Moshi.Builder()
 Add a Gradle dependency:
 
 ```groovy
-apt 'com.ryanharter.auto.value:auto-value-moshi:0.4.3'
+annotationProcessor 'com.ryanharter.auto.value:auto-value-moshi:0.4.3'
 
 // if you use the @MoshiAdapterFactory annotation, you'll need to add the 'annotations' artifact 
 // as a provided dependency:
 provided 'com.ryanharter.auto.value:auto-value-moshi-annotations:0.4.3'
 ```
-
-(Using the [android-apt](https://bitbucket.org/hvisser/android-apt) plugin)
 
 ## License
 


### PR DESCRIPTION
apt is deprecated in favor of annotationProcessor by the android gradle plugin v2.2