### PR TITLE
Add support for transient types via autotransient

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ Moshi moshi = new Moshi.Builder()
     .build();
 ```
 
+## Transient types
+
+To ignore certain properties from serialization, you can use the `@AutoTransient` annotation. This comes from a 
+shared transience annotations library and is an `api` dependency of the runtime artifact. You can annotate
+a property and it will be treated as `transient` for both serialization and deserialization. Note that
+this should only be applied to nullable properties.
+
 ## Download
 
 Add a Gradle dependency:

--- a/auto-value-moshi-runtime/build.gradle
+++ b/auto-value-moshi-runtime/build.gradle
@@ -1,11 +1,12 @@
-apply plugin: 'java'
+apply plugin: 'java-library'
 apply plugin: 'maven-publish'
 
 sourceCompatibility = versions.java
 targetCompatibility = versions.java
 
 dependencies {
-  compile libraries.moshi
+  api libraries.moshi
+  api libraries.autoTransient
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/auto-value-moshi/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtension.java
+++ b/auto-value-moshi/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtension.java
@@ -39,7 +39,6 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -703,17 +702,11 @@ public final class AutoValueMoshiExtension extends AutoValueExtension {
     if (builderField.isPresent()) {
       readMethod.addStatement("return $N.$L", builderField.get(), builderContext.buildMethod().get());
     } else {
-      StringBuilder format = new StringBuilder("return new ");
-      format.append(className.simpleName().replaceAll("\\$", ""));
-      format.append("(");
-      Iterator<FieldSpec> iterator = fields.values().iterator();
-      while (iterator.hasNext()) {
-        iterator.next();
-        format.append("$N");
-        if (iterator.hasNext()) format.append(", ");
-      }
-      format.append(")");
-      readMethod.addStatement(format.toString(), fields.values().toArray());
+      CodeBlock params = fields.values()
+          .stream()
+          .map(field -> CodeBlock.of("$N", field))
+          .collect(CodeBlock.joining(", "));
+      readMethod.addStatement("return new $T($L)", className, params);
     }
     return readMethod.build();
   }

--- a/auto-value-moshi/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtensionTest.java
+++ b/auto-value-moshi/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtensionTest.java
@@ -2094,7 +2094,7 @@ public final class AutoValueMoshiExtensionTest {
         .and().generatesSources(expected);
   }
 
-  @Test public void transientRequiredProperty_shouldFail() {
+  @Test public void transientRequiredPropertyShouldFail() {
     JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
         + "package test;\n"
         + "import com.google.auto.value.AutoValue;\n"

--- a/auto-value-moshi/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtensionTest.java
+++ b/auto-value-moshi/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtensionTest.java
@@ -2093,4 +2093,26 @@ public final class AutoValueMoshiExtensionTest {
         .compilesWithoutError()
         .and().generatesSources(expected);
   }
+
+  @Test public void transientRequiredProperty_shouldFail() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.squareup.moshi.Moshi;\n"
+        + "import com.squareup.moshi.JsonAdapter;\n"
+        + "import io.sweers.autotransient.AutoTransient;\n"
+        + "import com.ryanharter.auto.value.moshi.Nullable;\n"
+        + "@AutoValue public abstract class Test {\n"
+        + "  @AutoTransient public abstract String transientProperty();\n"
+        + "  public static JsonAdapter<Test> typeAdapter(Moshi moshi) {\n"
+        + "    return new AutoValue_Test.MoshiJsonAdapter(gson);\n"
+        + "  }\n"
+        + "}");
+
+    assertAbout(javaSources())
+        .that(Arrays.asList(nullable, source))
+        .processedWith(new AutoValueProcessor())
+        .failsToCompile()
+        .withErrorContaining("Required property cannot be transient!");
+  }
 }

--- a/auto-value-moshi/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtensionTest.java
+++ b/auto-value-moshi/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtensionTest.java
@@ -45,6 +45,7 @@ public final class AutoValueMoshiExtensionTest {
         + "import com.google.auto.value.AutoValue;\n"
         + "import com.squareup.moshi.JsonAdapter;\n"
         + "import com.squareup.moshi.Moshi;\n"
+        + "import io.sweers.autotransient.AutoTransient;\n"
         + "import java.util.Map;\n"
         + "import java.util.Set;\n"
         + "@AutoValue abstract class Test {\n"
@@ -67,6 +68,8 @@ public final class AutoValueMoshiExtensionTest {
         + "public abstract Map<String, Set<? super String>> g();\n"
         // Nullable type
         + "@Nullable abstract String i();\n"
+        // Transient property
+        + "@AutoTransient @Nullable abstract String j();\n"
         + "}\n"
     );
 
@@ -91,8 +94,8 @@ public final class AutoValueMoshiExtensionTest {
         + "@Generated(\"com.ryanharter.auto.value.moshi.AutoValueMoshiExtension\")\n"
         + "final class AutoValue_Test extends $AutoValue_Test {\n"
         + "  AutoValue_Test(String a, int[] b, int c, String d, Map<String, Number> e, Set<? extends String> f,\n"
-        + "      Map<String, Set<? super String>> g, @Nullable String i) {\n"
-        + "    super(a, b, c, d, e, f, g, i);\n"
+        + "      Map<String, Set<? super String>> g, @Nullable String i, @Nullable String j) {\n"
+        + "    super(a, b, c, d, e, f, g, i, j);\n"
         + "  }\n"
         + "\n"
         + "  public static final class MoshiJsonAdapter extends JsonAdapter<Test> {\n"
@@ -169,7 +172,7 @@ public final class AutoValueMoshiExtensionTest {
         + "        }\n"
         + "      }\n"
         + "      reader.endObject();\n"
-        + "      return new AutoValue_Test(a, b, c, d, e, f, g, i);\n"
+        + "      return new AutoValue_Test(a, b, c, d, e, f, g, i, null);\n"
         + "    }\n"
         + "    @Override\n"
         + "    public void toJson(JsonWriter writer, Test value) throws IOException {\n"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,6 +6,7 @@ ext {
         // Main dependencies
         javaPoet      : '1.12.0',
         autoCommon    : '0.10',
+        autoTransient : '1.0.0',
         autoValue     : '1.7',
         autoService   : '1.0-rc6',
         guava         : '27.1-jre',
@@ -22,6 +23,7 @@ ext {
     libraries = [
         javaPoet            : "com.squareup:javapoet:$versions.javaPoet",
         autoCommon          : "com.google.auto:auto-common:$versions.autoCommon",
+        autoTransient       : "io.sweers.autotransient:autotransient:${versions.autoTransient}",
         autoValue           : "com.google.auto.value:auto-value:$versions.autoValue",
         autoValueAnnotations: "com.google.auto.value:auto-value-annotations:$versions.autoValue",
         autoService         : "com.google.auto.service:auto-service:$versions.autoService",


### PR DESCRIPTION
Mostly a port from https://github.com/rharter/auto-value-gson/pull/207

This switches to a shared `@AutoTransient` annotation/artifact for marking fields as effectively transient. Note that this is a slight behavior change too - there is no support for serialization or deserialization-only. This treats it like a regular `transient` modifier, and if a consumer only wants serialization for just one type, they should make their own delegating adapter that only forwards the type they want to support.

Will add a full test once #150 is in as it would otherwise have a lot of conflicts

Resolves #55.