### PR TITLE
Generate proguard rules

### DIFF
--- a/auto-value-moshi/build.gradle
+++ b/auto-value-moshi/build.gradle
@@ -37,6 +37,7 @@ targetCompatibility = versions.java
 dependencies {
   annotationProcessor libraries.incapProcessor
   annotationProcessor libraries.autoService
+  annotationProcessor libraries.autoValue
   compileOnly libraries.incap
   compileOnly libraries.autoService
 

--- a/auto-value-moshi/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtension.java
+++ b/auto-value-moshi/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtension.java
@@ -272,7 +272,7 @@ public final class AutoValueMoshiExtension extends AutoValueExtension {
     ProguardConfig proguardConfig = ProguardConfig.create(
         generateExternalAdapter,
         proguardTarget,
-        adapterFqcn.canonicalName(),
+        adapterFqcn,
         adapterConstructorParams,
         qualifierProperties
     );

--- a/auto-value-moshi/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtension.java
+++ b/auto-value-moshi/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtension.java
@@ -8,6 +8,8 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.ryanharter.auto.value.moshi.ProguardConfig.QualifierAdapterProperty;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ArrayTypeName;
 import com.squareup.javapoet.ClassName;
@@ -44,6 +46,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
@@ -207,6 +210,7 @@ public final class AutoValueMoshiExtension extends AutoValueExtension {
     ClassName autoValueClassName = ClassName.get(context.autoValueClass());
     TypeVariableName[] genericTypeNames = null;
 
+    ClassName superclassToExtend = ClassName.get(context.packageName(), classToExtend);
     TypeName superclass;
 
     if (shouldCreateGenerics) {
@@ -214,7 +218,7 @@ public final class AutoValueMoshiExtension extends AutoValueExtension {
       for (int i = 0; i < typeParams.size(); i++) {
         genericTypeNames[i] = TypeVariableName.get(typeParams.get(i));
       }
-      superclass = ParameterizedTypeName.get(ClassName.get(context.packageName(), classToExtend),
+      superclass = ParameterizedTypeName.get(superclassToExtend,
               genericTypeNames);
     } else {
       superclass = TypeVariableName.get(classToExtend);
@@ -240,6 +244,53 @@ public final class AutoValueMoshiExtension extends AutoValueExtension {
         AutoValueMoshiExtension.class
     );
 
+    ClassName proguardTarget = ClassName.get(context.autoValueClass());
+    ClassName adapterFqcn = generateExternalAdapter
+        ? ClassName.get(context.packageName(), adapterClassName)
+        : superclassToExtend.nestedClass(adapterClassName);
+    List<String> adapterConstructorParams = Lists.newArrayList();
+    typeAdapterBuilder.methodSpecs.stream().filter(MethodSpec::isConstructor).findFirst()
+        .ifPresent(c -> {
+          for (ParameterSpec p : c.parameters) {
+            adapterConstructorParams.add(proguardNameOf(p.type));
+          }
+        });
+
+    Set<QualifierAdapterProperty> qualifierProperties = Sets.newLinkedHashSet();
+    for (FieldSpec field : typeAdapterBuilder.fieldSpecs) {
+      if (!field.annotations.isEmpty() && ADAPTER_CLASS_NAME.equals(rawType(field.type))) {
+        qualifierProperties.add(
+            QualifierAdapterProperty.create(
+                field.name,
+                field.annotations.stream()
+                    .map(a -> (ClassName) a.type)
+                    .collect(Collectors.toSet()))
+        );
+      }
+    }
+
+    ProguardConfig proguardConfig = ProguardConfig.create(
+        generateExternalAdapter,
+        proguardTarget,
+        adapterFqcn.canonicalName(),
+        adapterConstructorParams,
+        qualifierProperties
+    );
+
+    Filer filer = context.processingEnvironment().getFiler();
+    Runnable writeProguardFile = () -> {
+      try {
+        proguardConfig.writeTo(filer, context.autoValueClass());
+      } catch (IOException e) {
+        context.processingEnvironment().getMessager()
+            .printMessage(Diagnostic.Kind.ERROR,
+                String.format(
+                    "Failed to write proguard file for element \"%s\" with reason \"%s\"",
+                    context.autoValueClass(),
+                    e.getMessage()));
+      }
+    };
+
     if (generateExternalAdapter(context.autoValueClass())) {
       typeAdapterBuilder.addOriginatingElement(context.autoValueClass());
       generatedAnnotation.ifPresent(typeAdapterBuilder::addAnnotation);
@@ -247,7 +298,7 @@ public final class AutoValueMoshiExtension extends AutoValueExtension {
           .skipJavaLangImports(true)
           .build();
       try {
-        javaFile.writeTo(context.processingEnvironment().getFiler());
+        javaFile.writeTo(filer);
       } catch (IOException e) {
         context.processingEnvironment().getMessager()
             .printMessage(Diagnostic.Kind.ERROR,
@@ -256,6 +307,7 @@ public final class AutoValueMoshiExtension extends AutoValueExtension {
                     context.autoValueClass(),
                     e.getMessage()));
       }
+      writeProguardFile.run();
       return null;
     } else {
       TypeSpec typeAdapter = typeAdapterBuilder.addModifiers(STATIC).build();
@@ -276,6 +328,8 @@ public final class AutoValueMoshiExtension extends AutoValueExtension {
       } else {
         subclass.addModifiers(ABSTRACT);
       }
+
+      writeProguardFile.run();
 
       return JavaFile.builder(context.packageName(), subclass.build()).build().toString();
     }
@@ -745,5 +799,34 @@ public final class AutoValueMoshiExtension extends AutoValueExtension {
       block.add("$T.class", type);
     }
     return block.build();
+  }
+
+  @Nullable
+  private static ClassName rawType(TypeName typeName) {
+    if (typeName instanceof ClassName) {
+      return (ClassName) typeName;
+    } else if (typeName instanceof ArrayTypeName) {
+      return rawType(((ArrayTypeName) typeName).componentType);
+    } else if (typeName instanceof ParameterizedTypeName) {
+      return ((ParameterizedTypeName) typeName).rawType;
+    } else if (typeName instanceof WildcardTypeName) {
+      return rawType(((WildcardTypeName) typeName).upperBounds.get(0));
+    } else {
+      return null;
+    }
+  }
+
+  private static String proguardNameOf(TypeName typeName) {
+    if (typeName instanceof ClassName) {
+      return ((ClassName) typeName).canonicalName();
+    } else if (typeName instanceof ArrayTypeName) {
+      return proguardNameOf(((ArrayTypeName) typeName).componentType) + "[]";
+    } else if (typeName instanceof ParameterizedTypeName) {
+      return ((ParameterizedTypeName) typeName).rawType.canonicalName();
+    } else if (typeName instanceof TypeVariableName) {
+      return "java.lang.Object";
+    } else {
+      throw new UnsupportedOperationException("Unrecognized TypeName type: " + typeName);
+    }
   }
 }

--- a/auto-value-moshi/src/main/java/com/ryanharter/auto/value/moshi/ProguardConfig.java
+++ b/auto-value-moshi/src/main/java/com/ryanharter/auto/value/moshi/ProguardConfig.java
@@ -31,7 +31,7 @@ import static javax.tools.StandardLocation.CLASS_OUTPUT;
 abstract class ProguardConfig {
   abstract boolean isExternal();
   abstract ClassName targetClass();
-  abstract String adapterName();
+  abstract ClassName adapterName();
   abstract List<String> adapterConstructorParams();
   abstract Set<QualifierAdapterProperty> qualifierProperties();
   abstract String outputFile();
@@ -39,7 +39,7 @@ abstract class ProguardConfig {
   static ProguardConfig create(
       boolean isExternal,
       ClassName targetClass,
-      String adapterName,
+      ClassName adapterName,
       List<String> adapterConstructorParams,
       Set<QualifierAdapterProperty> qualifierProperties) {
     String outputFile = "META-INF/proguard/avm-" + targetClass.canonicalName() + ".pro";
@@ -70,8 +70,7 @@ abstract class ProguardConfig {
     // }
     //
     String targetName = targetClass().canonicalName();
-    String adapterCanonicalName
-        = ClassName.get(targetClass().packageName(), adapterName()).canonicalName();
+    String adapterCanonicalName = adapterName().canonicalName();
 
     if (isExternal()) {
       // Keep the class name for Moshi's reflective lookup based on it

--- a/auto-value-moshi/src/main/java/com/ryanharter/auto/value/moshi/ProguardConfig.java
+++ b/auto-value-moshi/src/main/java/com/ryanharter/auto/value/moshi/ProguardConfig.java
@@ -83,46 +83,48 @@ abstract class ProguardConfig {
           .append("\n");
     }
 
-    out.append("-if class ")
-        .append(targetName)
-        .append("\n");
-    out.append("-keep class ")
-        .append(adapterCanonicalName)
-        .append(" {\n");
+    if (isExternal() || !qualifierProperties().isEmpty()) {
+      out.append("-if class ")
+          .append(targetName)
+          .append("\n");
+      out.append("-keep class ")
+          .append(adapterCanonicalName)
+          .append(" {\n");
 
-    if (isExternal()) {
-      // Keep the constructor for Moshi's reflective lookup
-      String constructorArgs = String.join(",", adapterConstructorParams());
-      out.append("    public <init>(")
-          .append(constructorArgs)
-          .append(");\n");
-    }
-    // Keep any qualifier properties
-    for (QualifierAdapterProperty qualifierProperty : qualifierProperties()) {
-      out.append("    private com.squareup.moshi.JsonAdapter ")
-          .append(qualifierProperty.name())
-          .append(";\n");
-    }
-    out.append("}\n");
+      if (isExternal()) {
+        // Keep the constructor for Moshi's reflective lookup
+        String constructorArgs = String.join(",", adapterConstructorParams());
+        out.append("    public <init>(")
+            .append(constructorArgs)
+            .append(");\n");
+      }
+      // Keep any qualifier properties
+      for (QualifierAdapterProperty qualifierProperty : qualifierProperties()) {
+        out.append("    private com.squareup.moshi.JsonAdapter ")
+            .append(qualifierProperty.name())
+            .append(";\n");
+      }
+      out.append("}\n");
 
-    qualifierProperties().stream()
-        .flatMap(prop -> prop.qualifiers().stream())
-        .map(ClassName::canonicalName)
-        .sorted()
-        .forEach(qualifier -> {
-          try {
-            out.append("-if class ")
-                .append(targetName)
-                .append("\n")
-                .append("-keep @interface ")
-                .append(qualifier)
-                .append("\n");
-          } catch (IOException e) {
-            // Annoyingly in Java lambdas, this block does not inherit the throws signature of the
-            // method this is run in.
-            throw new RuntimeException(e);
-          }
-        });
+      qualifierProperties().stream()
+          .flatMap(prop -> prop.qualifiers().stream())
+          .map(ClassName::canonicalName)
+          .sorted()
+          .forEach(qualifier -> {
+            try {
+              out.append("-if class ")
+                  .append(targetName)
+                  .append("\n")
+                  .append("-keep @interface ")
+                  .append(qualifier)
+                  .append("\n");
+            } catch (IOException e) {
+              // Annoyingly in Java lambdas, this block does not inherit the throws signature of the
+              // method this is run in.
+              throw new RuntimeException(e);
+            }
+          });
+    }
   }
 
   /**

--- a/auto-value-moshi/src/main/java/com/ryanharter/auto/value/moshi/ProguardConfig.java
+++ b/auto-value-moshi/src/main/java/com/ryanharter/auto/value/moshi/ProguardConfig.java
@@ -1,0 +1,142 @@
+package com.ryanharter.auto.value.moshi;
+
+import com.google.auto.value.AutoValue;
+import com.squareup.javapoet.ClassName;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.processing.Filer;
+import javax.lang.model.element.Element;
+
+import static javax.tools.StandardLocation.CLASS_OUTPUT;
+
+/**
+ * Represents a proguard configuration for a given spec. This covers three main areas:
+ * <ul>
+ * <li>Keeping the target class name to Moshi's reflective lookup of the adapter if it's external.</li>
+ * <li>Keeping the generated adapter class name + public constructor for reflective lookup if it's external.</li>
+ * <li>Keeping any used JsonQualifier annotations and the properties they are attached to.</li>
+ * <li>If the target class has default parameter values, also keeping the associated synthetic constructor as well as the DefaultConstructorMarker type Kotlin adds to it.</li>
+ * </ul>
+ * <p>
+ * Each rule is intended to be as specific and targeted as possible to reduce footprint, and each is
+ * conditioned on usage of the original target type.
+ * <p>
+ * To keep this processor as an {@code ISOLATING} incremental processor, we generate one file per
+ * target class with a deterministic name (see {@link #outputFile}) with an appropriate originating
+ * element.
+ */
+@AutoValue
+abstract class ProguardConfig {
+  abstract boolean isExternal();
+  abstract ClassName targetClass();
+  abstract String adapterName();
+  abstract List<String> adapterConstructorParams();
+  abstract Set<QualifierAdapterProperty> qualifierProperties();
+  abstract String outputFile();
+
+  static ProguardConfig create(
+      boolean isExternal,
+      ClassName targetClass,
+      String adapterName,
+      List<String> adapterConstructorParams,
+      Set<QualifierAdapterProperty> qualifierProperties) {
+    String outputFile = "META-INF/proguard/avm-" + targetClass.canonicalName() + ".pro";
+    return new AutoValue_ProguardConfig(isExternal,
+        targetClass,
+        adapterName,
+        adapterConstructorParams,
+        qualifierProperties,
+        outputFile);
+  }
+
+  /** Writes this to {@code filer}. */
+  final void writeTo(Filer filer, Element... originatingElements) throws IOException {
+    try (Writer writer = filer.createResource(CLASS_OUTPUT, "", outputFile(), originatingElements)
+        .openWriter()) {
+      writeTo(writer);
+    }
+  }
+
+  private void writeTo(Appendable out) throws IOException {
+    //
+    // -if class {the target class}
+    // -keepnames class {the target class}
+    // -if class {the target class}
+    // -keep class {the generated adapter} {
+    //    <init>(...);
+    //    private final {adapter fields}
+    // }
+    //
+    String targetName = targetClass().canonicalName();
+    String adapterCanonicalName
+        = ClassName.get(targetClass().packageName(), adapterName()).canonicalName();
+
+    if (isExternal()) {
+      // Keep the class name for Moshi's reflective lookup based on it
+      out.append("-if class ")
+          .append(targetName)
+          .append("\n");
+      out.append("-keepnames class ")
+          .append(targetName)
+          .append("\n");
+    }
+
+    out.append("-if class ")
+        .append(targetName)
+        .append("\n");
+    out.append("-keep class ")
+        .append(adapterCanonicalName)
+        .append(" {\n");
+
+    if (isExternal()) {
+      // Keep the constructor for Moshi's reflective lookup
+      String constructorArgs = String.join(",", adapterConstructorParams());
+      out.append("    public <init>(")
+          .append(constructorArgs)
+          .append(");\n");
+    }
+    // Keep any qualifier properties
+    for (QualifierAdapterProperty qualifierProperty : qualifierProperties()) {
+      out.append("    private com.squareup.moshi.JsonAdapter ")
+          .append(qualifierProperty.name())
+          .append(";\n");
+    }
+    out.append("}\n");
+
+    qualifierProperties().stream()
+        .flatMap(prop -> prop.qualifiers().stream())
+        .map(ClassName::canonicalName)
+        .sorted()
+        .forEach(qualifier -> {
+          try {
+            out.append("-if class ")
+                .append(targetName)
+                .append("\n")
+                .append("-keep @interface ")
+                .append(qualifier)
+                .append("\n");
+          } catch (IOException e) {
+            // Annoyingly in Java lambdas, this block does not inherit the throws signature of the
+            // method this is run in.
+            throw new RuntimeException(e);
+          }
+        });
+  }
+
+  /**
+   * Represents a qualified property with its {@link #name} in the adapter fields and list of
+   * {@link #qualifiers} associated with it.
+   */
+  @AutoValue
+  abstract static class QualifierAdapterProperty {
+
+    static QualifierAdapterProperty create(String name, Set<ClassName> qualifiers) {
+      return new AutoValue_ProguardConfig_QualifierAdapterProperty(name, qualifiers);
+    }
+
+    abstract String name();
+    abstract Set<ClassName> qualifiers();
+  }
+}


### PR DESCRIPTION
Resolves #122 

This ports Moshi's proguard rule generation to here. There are some slight differences, namely:

* No need to Moshi's default constructor rules
* We only need to generate keeps for constructors and class names IFF it's generated externally, for moshi's reflective lookup.