### PR TITLE
Clean up misc gson name references in code and examples

### DIFF
--- a/auto-value-moshi-extension/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtensionTest.java
+++ b/auto-value-moshi-extension/src/test/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtensionTest.java
@@ -1627,7 +1627,7 @@ public final class AutoValueMoshiExtensionTest {
         .generatesSources(expected);
   }
 
-  @Test public void emitsWarningForWrongTypeAdapterTypeArgument() {
+  @Test public void emitsWarningForWrongJsonAdapterTypeArgument() {
     JavaFileObject source1 = JavaFileObjects.forSourceString("test.Foo", ""
         + "package test;\n"
         + "import com.google.auto.value.AutoValue;\n"
@@ -1655,7 +1655,7 @@ public final class AutoValueMoshiExtensionTest {
             + "test.Foo class. Skipping MoshiJsonAdapter generation.");
   }
 
-  @Test public void emitsWarningForNoTypeAdapterTypeArgument() {
+  @Test public void emitsWarningForNoJsonAdapterTypeArgument() {
     JavaFileObject source1 = JavaFileObjects.forSourceString("test.Foo", ""
         + "package test;\n"
         + "import com.google.auto.value.AutoValue;\n"
@@ -2456,8 +2456,8 @@ public final class AutoValueMoshiExtensionTest {
         + "import com.ryanharter.auto.value.moshi.Nullable;\n"
         + "@AutoValue public abstract class Test {\n"
         + "  @AutoTransient public abstract String transientProperty();\n"
-        + "  public static JsonAdapter<Test> typeAdapter(Moshi moshi) {\n"
-        + "    return new AutoValue_Test.MoshiJsonAdapter(gson);\n"
+        + "  public static JsonAdapter<Test> jsonAdapter(Moshi moshi) {\n"
+        + "    return new AutoValue_Test.MoshiJsonAdapter(moshi);\n"
         + "  }\n"
         + "}");
 

--- a/auto-value-moshi-factory/src/test/java/com/ryanharter/auto/value/moshi/factory/AutoValueMoshiAdapterFactoryProcessorTest.java
+++ b/auto-value-moshi-factory/src/test/java/com/ryanharter/auto/value/moshi/factory/AutoValueMoshiAdapterFactoryProcessorTest.java
@@ -22,7 +22,7 @@ public final class AutoValueMoshiAdapterFactoryProcessorTest {
         + "  public abstract String getName();\n"
         + "  public abstract boolean isAwesome();\n"
         + "}");
-    // Source2's typeAdapter method accepts no parameter, which is valid for the processor factory
+    // Source2's jsonAdapter method accepts no parameter, which is valid for the processor factory
     JavaFileObject source2 = JavaFileObjects.forSourceString("test.Bar", ""
         + "package test;\n"
         + "import com.google.auto.value.AutoValue;\n"

--- a/example/src/main/java/com/ryanharter/auto/value/moshi/example/SampleJsonAdapterFactory.java
+++ b/example/src/main/java/com/ryanharter/auto/value/moshi/example/SampleJsonAdapterFactory.java
@@ -4,8 +4,8 @@ import com.ryanharter.auto.value.moshi.MoshiAdapterFactory;
 import com.squareup.moshi.JsonAdapter;
 
 @MoshiAdapterFactory
-public abstract class SampleTypeAdapterFactory implements JsonAdapter.Factory {
+public abstract class SampleJsonAdapterFactory implements JsonAdapter.Factory {
     public static JsonAdapter.Factory create() {
-        return new AutoValueMoshi_SampleTypeAdapterFactory();
+        return new AutoValueMoshi_SampleJsonAdapterFactory();
     }
 }

--- a/example/src/test/java/com/ryanharter/auto/value/moshi/example/PersonTest.java
+++ b/example/src/test/java/com/ryanharter/auto/value/moshi/example/PersonTest.java
@@ -22,7 +22,7 @@ public class PersonTest {
         final DateFormat df = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
 
         Moshi moshi = new Moshi.Builder()
-                .add(SampleTypeAdapterFactory.create())
+                .add(SampleJsonAdapterFactory.create())
                 .build();
         Person person = Person.builder()
                 .name("Piasy")
@@ -49,7 +49,7 @@ public class PersonTest {
         expectedException.expectMessage("age cannot be negative");
 
         Moshi moshi = new Moshi.Builder()
-                .add(SampleTypeAdapterFactory.create())
+                .add(SampleJsonAdapterFactory.create())
                 .build();
 
         //language=json
@@ -58,9 +58,9 @@ public class PersonTest {
     }
 
     @Test
-    public void testGsonWithDefaults() throws IOException {
+    public void testMoshiWithDefaults() throws IOException {
         Moshi moshi = new Moshi.Builder()
-                .add(SampleTypeAdapterFactory.create())
+                .add(SampleJsonAdapterFactory.create())
                 .build();
 
         // "name" and "gender" are unspecified. Should default to "Jane Doe" and 23

--- a/example/src/test/java/com/ryanharter/auto/value/moshi/example/WebResponseTest.java
+++ b/example/src/test/java/com/ryanharter/auto/value/moshi/example/WebResponseTest.java
@@ -12,7 +12,7 @@ import static junit.framework.TestCase.assertEquals;
 
 public class WebResponseTest {
     Moshi moshi = new Moshi.Builder()
-            .add(SampleTypeAdapterFactory.create())
+            .add(SampleJsonAdapterFactory.create())
             .build();
 
     @Test

--- a/example/src/test/java/com/ryanharter/auto/value/moshi/example/wildgenerics/WildGenericsTest.java
+++ b/example/src/test/java/com/ryanharter/auto/value/moshi/example/wildgenerics/WildGenericsTest.java
@@ -1,7 +1,7 @@
 package com.ryanharter.auto.value.moshi.example.wildgenerics;
 
 import com.ryanharter.auto.value.moshi.example.Address;
-import com.ryanharter.auto.value.moshi.example.SampleTypeAdapterFactory;
+import com.ryanharter.auto.value.moshi.example.SampleJsonAdapterFactory;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
@@ -21,7 +21,7 @@ public final class WildGenericsTest {
         + "\"city\":\"barCity\"}],\"topLevelNonGeneric\":\"topLevelNonGeneric\"}";
 
     Moshi moshi = new Moshi.Builder()
-        .add(SampleTypeAdapterFactory.create())
+        .add(SampleJsonAdapterFactory.create())
         .build();
     JsonAdapter<AddressGenericBase> adapter = moshi.adapter(AddressGenericBase.class);
     AddressGenericBase instance = adapter.fromJson(json);
@@ -47,7 +47,7 @@ public final class WildGenericsTest {
         + "\"city\":\"topCollectionCity\"}]}";
 
     Moshi moshi = new Moshi.Builder()
-        .add(SampleTypeAdapterFactory.create())
+        .add(SampleJsonAdapterFactory.create())
         .build();
     Type token = Types.newParameterizedType(DoubleGeneric.class, Address.class);
     JsonAdapter<DoubleGeneric<Address>> adapter = moshi.adapter(token);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 GROUP=com.ryanharter.auto.value
 VERSION_NAME=0.4.8-SNAPSHOT
 
-POM_DESCRIPTION=AutoValue extension that generates a Moshi JsonAdapter.
+POM_DESCRIPTION=AutoValue extension that generates a Moshi JsonAdapter for JSON serialization of AutoValue classes.
 
 POM_URL=https://github.com/rharter/auto-value-moshi/
 POM_SCM_URL=https://github.com/rharter/auto-value-moshi/

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 GROUP=com.ryanharter.auto.value
 VERSION_NAME=0.4.8-SNAPSHOT
 
-POM_DESCRIPTION=AutoValue extension that creates a Moshi TypeAdapterFactory
+POM_DESCRIPTION=AutoValue extension that generates a Moshi JsonAdapter.
 
 POM_URL=https://github.com/rharter/auto-value-moshi/
 POM_SCM_URL=https://github.com/rharter/auto-value-moshi/


### PR DESCRIPTION
Leftovers from porting logic from auto-value-gson