### PR TITLE
Fix createReadMethod return statement constructor type

### DIFF
--- a/auto-value-moshi-extension/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtension.java
+++ b/auto-value-moshi-extension/src/main/java/com/ryanharter/auto/value/moshi/AutoValueMoshiExtension.java
@@ -730,7 +730,7 @@ public final class AutoValueMoshiExtension extends AutoValueExtension {
       readMethod.addStatement("return $N.$L", builderField.get(), builderContext.buildMethod().get());
     } else {
       CodeBlock params = CodeBlock.join(constructorCall, ", ");
-      readMethod.addStatement("return new $T($L)", className, params);
+      readMethod.addStatement("return new $N($L)", className.simpleName().replaceAll("\\$", ""), params);
     }
     return readMethod.build();
   }


### PR DESCRIPTION
Fixes #173.
version`0.4.7` has been generating return statement correctly. Return statement constructor type name is fixed using the same approach from `0.4.7`.